### PR TITLE
Add playback pause event

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,7 @@ player.attachTo(playerElement);
     <footer class="footer"></footer>
     <script type="text/javascript" charset="utf-8" src="j/main.js" async></script>
     <script type="text/javascript" charset="utf-8" src="j/editor/ace.js" async></script>
-    <script type="text/javascript" charset="utf-8" src="//cdn.clappr.io/latest/clappr.js"></script>
+    <script type="text/javascript" charset="utf-8" src="https://cdn.jsdelivr.net/clappr/latest/clappr.min.js"></script>
     <script type="text/javascript" charset="utf-8" src="/latest/clappr-chromecast-plugin.js"></script>
     <script>
       var urlParams;

--- a/src/chromecast_playback.js
+++ b/src/chromecast_playback.js
@@ -98,14 +98,22 @@ export default class ChromecastPlayback extends Playback {
         this.isBuffering = false
         this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
       }
-      this.trigger(Events.PLAYBACK_PLAY, this.name)
+      if (this.prevState !== this.currentMedia.playerState) {
+        this.trigger(Events.PLAYBACK_PLAY, this.name)
+      }
     } else if (this.currentMedia.playerState === 'IDLE') {
       if (this.isBuffering) {
         this.isBuffering = false
         this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
       }
       this.trigger(Events.PLAYBACK_ENDED, this.name)
+    } else if (this.currentMedia.playerState === 'PAUSED') {
+      if (this.prevState !== this.currentMedia.playerState) {
+        this.trigger(Events.PLAYBACK_PAUSE, this.name)
+      }
     }
+
+    this.prevState = this.currentMedia.playerState
   }
 
   updateMediaControl() {


### PR DESCRIPTION
* trigger Chromecast playback pause events
* avoid same event to be triggered several consecutive times
* fix Clappr player URL in demo page

Motivations : we needed to track player events (_for metrics_) also while playing media using Chromecast plugin. (_at least play & pause events_).
