### PR TITLE
Allow custom poster for Chromecasting only

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The plugin parameters are passed through the embed parameters object under the `
   - seriesTitle: TV series title (TV episode only)
   - season: TV episode season (TV episode only)
   - episode: TV episode number (TV episode only)
+- poster: a URL for an image that should be used as a poster when casting (optional)
 - customData: an object that can be used to pass additional parameters to a custom receiver (optional)
 
 

--- a/src/chromecast.js
+++ b/src/chromecast.js
@@ -187,7 +187,7 @@ export default class ChromecastPlugin extends UICorePlugin {
     let options = assign({}, this.originalPlayback.options, {
       currentMedia: mediaSession,
       mediaControl: this.core.mediaControl,
-      poster: this.core.options.poster,
+      poster: this.options.poster || this.core.options.poster,
       settings: this.originalPlayback.settings
     })
     this.src = this.originalPlayback.src
@@ -287,6 +287,9 @@ export default class ChromecastPlugin extends UICorePlugin {
 
     if (this.options.media.images) {
       metadata.images = this.options.media.images.map((url) => new chrome.cast.Image(url))
+    }
+    if (!metadata.images && this.options.poster) {
+      metadata.images = [new chrome.cast.Image(this.options.poster)]
     }
     if (!metadata.images && this.core.options.poster) {
       metadata.images = [new chrome.cast.Image(this.core.options.poster)]


### PR DESCRIPTION
The existing code uses the core poster option; but I wanted to be able to provide a poster that only the Chromecast plugin would put up, but would not be the poster for the player as a whole. If there's a better way to do this, I'm open to it.