### PR TITLE
fix: ensure page is secure with Chrome >= 72

### DIFF
--- a/src/chromecast.js
+++ b/src/chromecast.js
@@ -60,7 +60,7 @@ export default class ChromecastPlugin extends UICorePlugin {
     this.bootMaxTryCount = this.options.bootMaxTryCount || 6  // Default is 6 attempts (3 seconds)
     this.bootTryCount = 0
 
-    if (Browser.isChrome) {
+    if (this.isBootable()) {
       this.appId = this.options.appId || DEFAULT_CLAPPR_APP_ID
       this.deviceState = DEVICE_STATE.IDLE
       this.embedScript()
@@ -77,6 +77,28 @@ export default class ChromecastPlugin extends UICorePlugin {
       this.listenTo(this.container, Events.CONTAINER_PLAY, this.containerPlay)
       this.listenTo(this.container, Events.CONTAINER_ENDED, this.sessionStopped)
     }
+  }
+
+  isBootable() {
+    // Browser must be Chrome
+    if (!Browser.isChrome) {
+      return false
+    }
+
+    // Chrome lesser than or equals to 71
+    // does not require secure page
+    if (Browser.version <= 71) {
+      return true
+    }
+
+    // Chrome greater than or equals to 72
+    // require secure page
+    return this.isSecure()
+  }
+
+  isSecure()
+  {
+    return window.location.protocol === 'https:'
   }
 
   enable() {

--- a/src/chromecast.js
+++ b/src/chromecast.js
@@ -96,8 +96,7 @@ export default class ChromecastPlugin extends UICorePlugin {
     return this.isSecure()
   }
 
-  isSecure()
-  {
+  isSecure() {
     return window.location.protocol === 'https:'
   }
 


### PR DESCRIPTION
Chrome version 72 require a secure https url.

Source: [https://plus.google.com/+LeonNicholls/posts/jhTafR5dhGC](https://plus.google.com/+LeonNicholls/posts/jhTafR5dhGC)

This fix ensure that page is secure if chrome is greater than or equals to 72. _(otherwise attempt to boot cast api, and therefore is backward compatible)_.